### PR TITLE
Native memory management overhaul

### DIFF
--- a/FalcoSecurity.Plugin.Sdk.Generators.Staging/PluginNativeExports.cs
+++ b/FalcoSecurity.Plugin.Sdk.Generators.Staging/PluginNativeExports.cs
@@ -1,107 +1,106 @@
 // auto-generated
-
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using FalcoSecurity.Plugin.Sdk.Events;
 using FalcoSecurity.Plugin.Sdk.Fields;
 
-namespace FalcoSecurity.Plugin.Sdk
+namespace FalcoSecurity.Plugin.Sdk.DummyPlugin
 {
-    using PluginStateOpaquePtr = IntPtr;
     using EventSourceInstanceOpaquePtr = IntPtr;
 
     public static unsafe class Plugin_NativeExports
     {
         private static IntPtr _pluginName;
-
         private static IntPtr _pluginDescription;
-
         private static IntPtr _pluginRequiredApiVersion;
-
         private static IntPtr _pluginVersion;
-
         private static IntPtr _pluginContact;
 
-        private static IntPtr _eventSourceName;
 
-        private static IntPtr _pluginSchema = IntPtr.Zero;
+        private static IntPtr _eventSourceName;
+        private static IntPtr _openParamsJsonArray;
+        private static ulong _instanceId = 0;
+        private static IDictionary<ulong, IEventSourceInstance> _instanceTable;
+
+
 
         private static IntPtr _pluginLastError = IntPtr.Zero;
 
-        private static IntPtr _openParamsJsonArray;
 
         private static IntPtr _fieldsJsonArray;
-
-        private static uint _pluginId = 0;
-
-        private static Plugin _plugin = new();
-
-        private const bool _pluginHasEventSourceCapability = true;
-
-        private const bool _pluginHasFieldExtractCapability = true;
-
-        private const bool _pluginHasConfig = true;
-
-        private static ulong _instanceId = 0;
-
+        private static IntPtr _extractionSourcesJsonArray;
         private static ExtractionRequestPool _requestPool;
-
-        private static IDictionary<ulong, IEventSourceInstance> _instanceTable;
-
         private static int _numFields;
 
+
+        private static uint _pluginId = 0;
+        private static Plugin _plugin = new();
+
         // must be non-null, or some funcs like list_opem_params will early-exit
-        private static IntPtr _pluginState = Marshal.AllocHGlobal(1);
+        private static void* _pluginState = NativeMemory.Alloc(1);
 
         static Plugin_NativeExports()
         {
             /* 'demographic' strings the returned strings must remain valid until the plugin is destroyed. */
-            var pluginInfo = (FalcoPluginAttribute) Attribute.GetCustomAttribute(typeof(Plugin), typeof(FalcoPluginAttribute));
+
+            var pluginInfo = (FalcoPluginAttribute)Attribute.GetCustomAttribute(
+                typeof(Plugin),
+                typeof(FalcoPluginAttribute));
+
             _pluginId = pluginInfo.Id;
             _pluginDescription = Marshal.StringToCoTaskMemUTF8(pluginInfo.Description);
             _pluginRequiredApiVersion = Marshal.StringToCoTaskMemUTF8(pluginInfo.RequiredApiVersion);
             _pluginVersion = Marshal.StringToCoTaskMemUTF8(pluginInfo.Version);
             _pluginContact = Marshal.StringToCoTaskMemUTF8(pluginInfo.Contacts);
             _pluginName = Marshal.StringToCoTaskMemUTF8(pluginInfo.Name);
-            
-            /*
-            if (_pluginHasConfig)
-            {
-                if (_plugin.TryGenerateJsonSchema(out var jsonSchema))
-                {
-                    _pluginSchema = Marshal.StringToCoTaskMemUTF8(jsonSchema);
-                }
-            }
-            */
 
-#pragma warning disable CS0162 // Unreachable code detected
-            if (_pluginHasEventSourceCapability)
+
+
+
+            var eventSource = (IEventSource)_plugin;
+            _eventSourceName = Marshal.StringToCoTaskMemUTF8(eventSource.EventSourceName);
+            var openParams = eventSource.OpenParameters;
+            if (openParams != null && openParams.Count() > 0)
             {
-                var eventSource = (IEventSource) _plugin;
-                _eventSourceName = Marshal.StringToCoTaskMemUTF8(eventSource.EventSourceName);
-                var openParams = eventSource.OpenParameters;
                 var openParamsJson = JsonSerializer.Serialize(openParams);
                 _openParamsJsonArray = Marshal.StringToCoTaskMemUTF8(openParamsJson);
             }
-            else 
+            else
             {
                 _openParamsJsonArray = Marshal.StringToCoTaskMemUTF8("[]");
-            } 
-
-            if (_pluginHasFieldExtractCapability)
-            {
-               var fieldExtractor = (IFieldExtractor) _plugin;
-               var fields = fieldExtractor.Fields;
-               _numFields = fields.Count();
-               var fieldsJson = JsonSerializer.Serialize(fields);
-               _fieldsJsonArray = Marshal.StringToCoTaskMemUTF8(fieldsJson);
             }
-            else 
+
+
+
+            var fieldExtractor = (IFieldExtractor)_plugin;
+            var fields = fieldExtractor.Fields;
+
+            if (fields != null && fields.Count() > 0)
             {
+                _numFields = fields.Count();
+                var fieldsJson = JsonSerializer.Serialize(fields);
+                _fieldsJsonArray = Marshal.StringToCoTaskMemUTF8(fieldsJson);
+            }
+            else
+            {
+                _numFields = 0;
                 _fieldsJsonArray = Marshal.StringToCoTaskMemUTF8("[]");
             }
-#pragma warning restore CS0162 // Unreachable code detected
+
+            if (fieldExtractor.EventSourcesToExtract != null
+                && fieldExtractor.EventSourcesToExtract.Count() > 0)
+            {
+                var eventSourcesToExtractJson = JsonSerializer.Serialize(
+                    fieldExtractor.EventSourcesToExtract);
+                _extractionSourcesJsonArray = Marshal.StringToCoTaskMemUTF8(
+                    eventSourcesToExtractJson);
+            }
+            else
+            {
+                _extractionSourcesJsonArray = Marshal.StringToCoTaskMemUTF8("[]");
+            }
+
         }
 
         [UnmanagedCallersOnly(EntryPoint = "plugin_get_required_api_version", CallConvs = new[] { typeof(CallConvCdecl) })]
@@ -110,78 +109,8 @@ namespace FalcoSecurity.Plugin.Sdk
             return _pluginRequiredApiVersion;
         }
 
-        [UnmanagedCallersOnly(EntryPoint = "plugin_get_init_schema", CallConvs = new[] { typeof(CallConvCdecl) })]
-        public static IntPtr GetInitSchema(IntPtr schemaType)
-        {
-            if (_pluginSchema != IntPtr.Zero)
-            {
-                Marshal.WriteInt32(schemaType, (int)PluginSchemaType.Json);
-            }
-            else
-            {
-                Marshal.WriteInt32(schemaType, (int)PluginSchemaType.None);
-            }
-
-            return _pluginSchema;
-        }
-
-        [UnmanagedCallersOnly(EntryPoint = "plugin_init", CallConvs = new[] { typeof(CallConvCdecl) })]
-        public static PluginStateOpaquePtr Init(IntPtr configString, IntPtr returnCode)
-        {
-            if (_pluginHasEventSourceCapability)
-            {
-                _instanceTable = new Dictionary<ulong, IEventSourceInstance>();
-            }
-
-            if (_pluginHasFieldExtractCapability)
-            {
-                _requestPool = new ExtractionRequestPool(_numFields * 2);
-            }
-
-            Marshal.WriteInt32(returnCode, (int)PluginReturnCode.Success);
-            return _pluginState;
-        }
-
-        [UnmanagedCallersOnly(EntryPoint = "plugin_destroy", CallConvs = new[] { typeof(CallConvCdecl) })]
-        public static void Destroy(PluginStateOpaquePtr pluginState)
-        {
-            Marshal.FreeHGlobal(_pluginRequiredApiVersion);
-            Marshal.FreeHGlobal(_pluginName);
-            Marshal.FreeHGlobal(_pluginVersion);
-            Marshal.FreeHGlobal(_pluginSchema);
-            Marshal.FreeHGlobal(_pluginContact);
-            Marshal.FreeHGlobal(_pluginDescription);
-            Marshal.FreeHGlobal(_fieldsJsonArray);
-            Marshal.FreeHGlobal(_openParamsJsonArray);
-            Marshal.FreeHGlobal(pluginState);
-
-            try
-            {
-                if (typeof(IDisposable).IsAssignableFrom(_requestPool.Pool.GetType()))
-                {
-                    ((IDisposable)_requestPool.Pool).Dispose();
-                }
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(ex.ToString());
-            }
-
-            try
-            {
-                foreach(var i in _instanceTable.Values)
-                {
-                    i.Dispose();
-                }
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(ex.ToString());
-            }
-        }
-
         [UnmanagedCallersOnly(EntryPoint = "plugin_get_last_error", CallConvs = new[] { typeof(CallConvCdecl) })]
-        public static IntPtr GetLastError(PluginStateOpaquePtr pluginState)
+        public static IntPtr GetLastError(void* pluginState)
         {
             var lastError = _plugin.LastError ?? "cannot get error message: plugin last error not set.";
             _pluginLastError = Marshal.StringToCoTaskMemUTF8(lastError);
@@ -212,7 +141,62 @@ namespace FalcoSecurity.Plugin.Sdk
             return _pluginVersion;
         }
 
-#region Event sourcing capability API
+
+
+        [UnmanagedCallersOnly(EntryPoint = "plugin_init", CallConvs = new[] { typeof(CallConvCdecl) })]
+        public static void* Init(IntPtr configString, IntPtr returnCode)
+        {
+
+            _instanceTable = new Dictionary<ulong, IEventSourceInstance>();
+            _requestPool = new ExtractionRequestPool(_numFields * 2);
+
+            Marshal.WriteInt32(returnCode, (int)PluginReturnCode.Success);
+            return _pluginState;
+        }
+
+        [UnmanagedCallersOnly(EntryPoint = "plugin_destroy", CallConvs = new[] { typeof(CallConvCdecl) })]
+        public static void Destroy(void* pluginState)
+        {
+            Marshal.FreeCoTaskMem(_pluginName);
+            Marshal.FreeCoTaskMem(_pluginRequiredApiVersion);
+            Marshal.FreeCoTaskMem(_pluginVersion);
+            Marshal.FreeCoTaskMem(_pluginContact);
+            Marshal.FreeCoTaskMem(_pluginDescription);
+            NativeMemory.Free(pluginState);
+
+
+
+
+            Marshal.FreeCoTaskMem(_fieldsJsonArray);
+            try
+            {
+                if (typeof(IDisposable).IsAssignableFrom(_requestPool.Pool.GetType()))
+                {
+                    ((IDisposable)_requestPool.Pool).Dispose();
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(ex.ToString());
+            }
+
+
+            Marshal.FreeCoTaskMem(_eventSourceName);
+            Marshal.FreeCoTaskMem(_openParamsJsonArray);
+            try
+            {
+                foreach (var i in _instanceTable.Values)
+                {
+                    i.Dispose();
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(ex.ToString());
+            }
+
+        }
+
 
         [UnmanagedCallersOnly(EntryPoint = "plugin_get_id", CallConvs = new[] { typeof(CallConvCdecl) })]
         public static uint GetId()
@@ -220,16 +204,14 @@ namespace FalcoSecurity.Plugin.Sdk
             return _pluginId;
         }
 
-        // BEGIN_PLUGIN_CAP_DATA_SOURCE
         [UnmanagedCallersOnly(EntryPoint = "plugin_get_event_source", CallConvs = new[] { typeof(CallConvCdecl) })]
         public static IntPtr GetEventSourceName()
         {
             return _eventSourceName;
         }
-        // END_PLUGIN_CAP_DATA_SOURCE
 
         [UnmanagedCallersOnly(EntryPoint = "plugin_open", CallConvs = new[] { typeof(CallConvCdecl) })]
-        public static EventSourceInstanceOpaquePtr Open(PluginStateOpaquePtr pluginState, IntPtr paramsString, IntPtr returnCode)
+        public static EventSourceInstanceOpaquePtr Open(void* pluginState, IntPtr paramsString, IntPtr returnCode)
         {
             try
             {
@@ -253,7 +235,7 @@ namespace FalcoSecurity.Plugin.Sdk
 
                 return (IntPtr)_instanceId;
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 Console.Error.WriteLine(ex.ToString());
                 Marshal.WriteInt32(returnCode, (int)PluginReturnCode.Failure);
@@ -263,10 +245,10 @@ namespace FalcoSecurity.Plugin.Sdk
         }
 
         [UnmanagedCallersOnly(EntryPoint = "plugin_close", CallConvs = new[] { typeof(CallConvCdecl) })]
-        public static void Close(PluginStateOpaquePtr pluginState, EventSourceInstanceOpaquePtr instance)
+        public static void Close(void* pluginState, EventSourceInstanceOpaquePtr instance)
         {
-            var instanceId = (ulong) instance;
-            try 
+            var instanceId = (ulong)instance;
+            try
             {
                 var evtSourceInstance = _instanceTable[instanceId];
                 _plugin.Close(evtSourceInstance);
@@ -276,7 +258,7 @@ namespace FalcoSecurity.Plugin.Sdk
                 Console.Error.WriteLine(ex.ToString());
                 _plugin.LastError = ex.ToString();
             }
-            finally 
+            finally
             {
                 _instanceTable.Remove(instanceId);
             }
@@ -291,7 +273,7 @@ namespace FalcoSecurity.Plugin.Sdk
 
         /*
         [UnmanagedCallersOnly(EntryPoint = "plugin_get_progress", CallConvs = new[] { typeof(CallConvCdecl) })]
-        public static IntPtr GetReadProgress(PluginStateOpaquePtr pluginState, EventSourceInstanceOpaquePtr instance, IntPtr progress)
+        public static IntPtr GetReadProgress(void* pluginState, EventSourceInstanceOpaquePtr instance, IntPtr progress)
         {
             Marshal.WriteInt32(progress, 0);
             return IntPtr.Zero;
@@ -299,7 +281,7 @@ namespace FalcoSecurity.Plugin.Sdk
         */
 
         [UnmanagedCallersOnly(EntryPoint = "plugin_event_to_string", CallConvs = new[] { typeof(CallConvCdecl) })]
-        public static IntPtr EventToString(PluginStateOpaquePtr pluginState, IntPtr pluginEvent)
+        public static IntPtr EventToString(void* pluginState, IntPtr pluginEvent)
         {
             return _eventSourceName;
         }
@@ -311,7 +293,7 @@ namespace FalcoSecurity.Plugin.Sdk
         /// </remarks>
         [UnmanagedCallersOnly(EntryPoint = "plugin_next_batch", CallConvs = new[] { typeof(CallConvCdecl) })]
 
-        public static int GetNextEventsBatch(PluginStateOpaquePtr pluginState, EventSourceInstanceOpaquePtr instance, IntPtr numEvents, IntPtr events)
+        public static int GetNextEventsBatch(void* pluginState, EventSourceInstanceOpaquePtr instance, IntPtr numEvents, IntPtr events)
         {
             EventSourceInstanceContext? ctx = null;
             try
@@ -320,22 +302,20 @@ namespace FalcoSecurity.Plugin.Sdk
                 var evtSourceInstance = _instanceTable[instanceId];
                 ctx = evtSourceInstance.NextBatch();
 
-                Marshal.WriteInt32(numEvents, (int) ctx.BatchEventsNum);
+                Marshal.WriteInt32(numEvents, (int)ctx.BatchEventsNum);
 
-                Marshal.WriteIntPtr(
-                    events, 
-                    evtSourceInstance.EventBatch.UnderlyingArray);
+                events = (IntPtr)evtSourceInstance.EventBatch.UnderlyingArray;
 
                 if (ctx.IsEof)
                 {
-                    return (int) PluginReturnCode.Eof;
+                    return (int)PluginReturnCode.Eof;
                 }
                 else if (ctx.HasTimeout)
                 {
                     return (int)(ctx.BatchEventsNum > 0
                         ? PluginReturnCode.Success // partial batch flushed?
                         : PluginReturnCode.Timeout);
-                } 
+                }
                 else if (ctx.HasFailure)
                 {
                     Marshal.WriteInt32(numEvents, 0);
@@ -343,7 +323,7 @@ namespace FalcoSecurity.Plugin.Sdk
                     return (int)PluginReturnCode.Failure;
                 }
 
-                return (int) PluginReturnCode.Success;
+                return (int)PluginReturnCode.Success;
 
             }
             catch (Exception ex)
@@ -359,17 +339,18 @@ namespace FalcoSecurity.Plugin.Sdk
             }
         }
 
-#endregion
 
-#region Field extraction capability API
-
-        // BEGIN_PLUGIN_CAP_FIELD_EXTRACTION
         [UnmanagedCallersOnly(EntryPoint = "plugin_get_fields", CallConvs = new[] { typeof(CallConvCdecl) })]
         public static IntPtr GetFields()
         {
             return _fieldsJsonArray;
         }
-        // END_PLUGIN_CAP_FIELD_EXTRACTION
+
+        [UnmanagedCallersOnly(EntryPoint = "plugin_get_extract_event_sources", CallConvs = new[] { typeof(CallConvCdecl) })]
+        public static IntPtr GetExtractEventSources()
+        {
+            return _extractionSourcesJsonArray;
+        }
 
         /// <remarks>
         /// When returning extracted string values via plugin_extract_fields, 
@@ -377,14 +358,14 @@ namespace FalcoSecurity.Plugin.Sdk
         /// NOTE: freed on extractRequest.SetPtr
         /// </remarks>
         [UnmanagedCallersOnly(EntryPoint = "plugin_extract_fields", CallConvs = new[] { typeof(CallConvCdecl) })]
-        public static int ExtractFields(PluginStateOpaquePtr pluginState, IntPtr pluginEvent, int numFields, IntPtr fieldsPtr)
+        public static int ExtractFields(void* pluginState, IntPtr pluginEvent, int numFields, IntPtr fieldsPtr)
         {
             try
             {
-                var fieldExtractor = (IFieldExtractor) _plugin;
-                var eventReader = new EventReader((PluginEvent*) pluginEvent);
-                var fields = (PluginExtractField*) fieldsPtr;
-                for(var i = 0; i < numFields; i++)
+                var fieldExtractor = (IFieldExtractor)_plugin;
+                var eventReader = new EventReader((PluginEvent*)pluginEvent);
+                var fields = (PluginExtractField*)fieldsPtr;
+                for (var i = 0; i < numFields; i++)
                 {
                     var f = &fields[i];
                     var extractRequest = _requestPool.Pool.Get();
@@ -392,15 +373,15 @@ namespace FalcoSecurity.Plugin.Sdk
                     fieldExtractor.Extract(extractRequest, eventReader);
                     _requestPool.Pool.Return(extractRequest);
                 }
-                return (int) PluginReturnCode.Success;
+                return (int)PluginReturnCode.Success;
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 Console.Error.WriteLine(ex.ToString());
                 _plugin.LastError = ex.ToString();
                 return (int)PluginReturnCode.Failure;
             }
         }
-#endregion
+
     }
 }

--- a/FalcoSecurity.Plugin.Sdk.Generators/FalcoSecurity.Plugin.Sdk.Generators.csproj
+++ b/FalcoSecurity.Plugin.Sdk.Generators/FalcoSecurity.Plugin.Sdk.Generators.csproj
@@ -11,7 +11,7 @@
 		<IncludeBuildOutput>false</IncludeBuildOutput> <!-- Do not include the generator as a lib dependency -->
 
 		<Title>The source generator for FalcoSecurity.Plugin.Sdk</Title>
-		<VersionPrefix>0.5.0</VersionPrefix>
+		<VersionPrefix>0.5.1</VersionPrefix>
 		<VersionSuffix></VersionSuffix>
 		<Authors>mvenditto</Authors>
 		<Company>mvenditto</Company>

--- a/FalcoSecurity.Plugin.Sdk.Generators/FalcoSecurity.Plugin.Sdk.Generators.csproj
+++ b/FalcoSecurity.Plugin.Sdk.Generators/FalcoSecurity.Plugin.Sdk.Generators.csproj
@@ -11,7 +11,7 @@
 		<IncludeBuildOutput>false</IncludeBuildOutput> <!-- Do not include the generator as a lib dependency -->
 
 		<Title>The source generator for FalcoSecurity.Plugin.Sdk</Title>
-		<VersionPrefix>0.3.6</VersionPrefix>
+		<VersionPrefix>0.5.0</VersionPrefix>
 		<VersionSuffix></VersionSuffix>
 		<Authors>mvenditto</Authors>
 		<Company>mvenditto</Company>

--- a/FalcoSecurity.Plugin.Sdk.Generators/PluginNativeExports.sbncs
+++ b/FalcoSecurity.Plugin.Sdk.Generators/PluginNativeExports.sbncs
@@ -360,9 +360,9 @@ namespace {{namespace}}
                 ctx = evtSourceInstance.NextBatch();
 
                 Marshal.WriteInt32(numEvents, (int) ctx.BatchEventsNum);
-
-                events = (IntPtr) evtSourceInstance.EventBatch.UnderlyingArray;
-
+                PluginEvent* p = &evtSourceInstance.EventBatch.UnderlyingArray[0];
+                Marshal.WriteIntPtr(events, (IntPtr) p);
+                
                 if (ctx.IsEof)
                 {
                     return (int) PluginReturnCode.Eof;

--- a/FalcoSecurity.Plugin.Sdk.Generators/PluginNativeExports.sbncs
+++ b/FalcoSecurity.Plugin.Sdk.Generators/PluginNativeExports.sbncs
@@ -9,7 +9,6 @@ using FalcoSecurity.Plugin.Sdk.Fields;
 
 namespace {{namespace}}
 {
-    using PluginStateOpaquePtr = IntPtr;
     using EventSourceInstanceOpaquePtr = IntPtr;
 
     public static unsafe class {{class_name}}_NativeExports
@@ -41,9 +40,6 @@ namespace {{namespace}}
 
         private static uint _pluginId = 0;
         private static {{class_name}} _plugin = new();
-
-        // must be non-null, or some funcs like list_opem_params will early-exit
-        private static IntPtr _pluginState = Marshal.AllocHGlobal(1);
 
         static {{class_name}}_NativeExports()
         {
@@ -113,6 +109,18 @@ namespace {{namespace}}
 {{ end }}
         }
 
+        private static void FreeCoTaskMemAndNull(IntPtr ptr)
+        {
+            if (ptr == IntPtr.Zero || ptr == null)
+            {
+                return;
+            }
+
+            Marshal.FreeCoTaskMem(ptr);
+            
+            ptr = IntPtr.Zero;
+        }
+
     [UnmanagedCallersOnly(EntryPoint = "plugin_get_required_api_version", CallConvs = new[] { typeof(CallConvCdecl) })]
         public static IntPtr GetRequiredApiVersion()
         {
@@ -120,7 +128,7 @@ namespace {{namespace}}
         }
 
         [UnmanagedCallersOnly(EntryPoint = "plugin_get_last_error", CallConvs = new[] { typeof(CallConvCdecl) })]
-        public static IntPtr GetLastError(PluginStateOpaquePtr pluginState)
+        public static IntPtr GetLastError(void* pluginState)
         {
             var lastError = _plugin.LastError ?? "cannot get error message: plugin last error not set.";
             _pluginLastError = Marshal.StringToCoTaskMemUTF8(lastError);
@@ -169,34 +177,54 @@ namespace {{namespace}}
 {{ end }}
 
         [UnmanagedCallersOnly(EntryPoint = "plugin_init", CallConvs = new[] { typeof(CallConvCdecl) })]
-        public static PluginStateOpaquePtr Init(IntPtr configString, IntPtr returnCode)
+        public static void* Init(IntPtr configString, IntPtr returnCode)
         {
 {{ if has_event_sourcing_capability }}
             _instanceTable = new Dictionary<ulong, IEventSourceInstance>();
 {{- end -}}
 {{ if has_field_extraction_capability }}
-            _requestPool = new ExtractionRequestPool(_numFields * 2);
+            if (_numFields > 0)
+            {
+                _requestPool = new ExtractionRequestPool(_numFields * 2);
+            }
 {{ end }}         
-            Marshal.WriteInt32(returnCode, (int)PluginReturnCode.Success);
-            return _pluginState;
+            try
+            {
+                if (configString != IntPtr.Zero)
+                {
+                    var cfg = Marshal.PtrToStringUTF8(configString);
+                    _plugin.ConfigRaw = cfg;
+                }
+        
+                _plugin.Init();
+
+                Marshal.WriteInt32(returnCode, (int)PluginReturnCode.Success);
+            }
+            catch (Exception ex)
+            { 
+                Console.Error.WriteLine(ex.ToString());
+                Marshal.WriteInt32(returnCode, (int)PluginReturnCode.Failure);
+            }
+            
+            return NativeMemory.Alloc(1);
         }
 
         [UnmanagedCallersOnly(EntryPoint = "plugin_destroy", CallConvs = new[] { typeof(CallConvCdecl) })]
-        public static void Destroy(PluginStateOpaquePtr pluginState)
+        public static void Destroy(void* pluginState)
         {
-            Marshal.FreeHGlobal(_pluginName);
-            Marshal.FreeHGlobal(_pluginRequiredApiVersion);
-            Marshal.FreeHGlobal(_pluginVersion);
-            Marshal.FreeHGlobal(_pluginContact);
-            Marshal.FreeHGlobal(_pluginDescription);
-            Marshal.FreeHGlobal(pluginState);
+            FreeCoTaskMemAndNull(_pluginName);
+            FreeCoTaskMemAndNull(_pluginRequiredApiVersion);
+            FreeCoTaskMemAndNull(_pluginVersion);
+            FreeCoTaskMemAndNull(_pluginContact);
+            FreeCoTaskMemAndNull(_pluginDescription);
+            NativeMemory.Free(pluginState);
 
 {{ if has_configuration }}
-            Marshal.FreeHGlobal(_pluginSchema);
+            FreeCoTaskMemAndNull(_pluginSchema);
 {{ end }}
 
 {{ if has_field_extraction_capability }}
-            Marshal.FreeHGlobal(_fieldsJsonArray);
+            FreeCoTaskMemAndNull(_fieldsJsonArray);
             try
             {
                 if (typeof(IDisposable).IsAssignableFrom(_requestPool.Pool.GetType()))
@@ -210,8 +238,8 @@ namespace {{namespace}}
             }
 {{ end }}
 {{ if has_event_sourcing_capability }}
-            Marshal.FreeHGlobal(_eventSourceName);
-            Marshal.FreeHGlobal(_openParamsJsonArray);
+            FreeCoTaskMemAndNull(_eventSourceName);
+            FreeCoTaskMemAndNull(_openParamsJsonArray);
             try
             {
                 foreach(var i in _instanceTable.Values)
@@ -240,7 +268,7 @@ namespace {{namespace}}
         }
 
         [UnmanagedCallersOnly(EntryPoint = "plugin_open", CallConvs = new[] { typeof(CallConvCdecl) })]
-        public static EventSourceInstanceOpaquePtr Open(PluginStateOpaquePtr pluginState, IntPtr paramsString, IntPtr returnCode)
+        public static EventSourceInstanceOpaquePtr Open(void* pluginState, IntPtr paramsString, IntPtr returnCode)
         {
             try
             {
@@ -274,7 +302,7 @@ namespace {{namespace}}
         }
 
         [UnmanagedCallersOnly(EntryPoint = "plugin_close", CallConvs = new[] { typeof(CallConvCdecl) })]
-        public static void Close(PluginStateOpaquePtr pluginState, EventSourceInstanceOpaquePtr instance)
+        public static void Close(void* pluginState, EventSourceInstanceOpaquePtr instance)
         {
             var instanceId = (ulong) instance;
             try 
@@ -302,7 +330,7 @@ namespace {{namespace}}
 
         /*
         [UnmanagedCallersOnly(EntryPoint = "plugin_get_progress", CallConvs = new[] { typeof(CallConvCdecl) })]
-        public static IntPtr GetReadProgress(PluginStateOpaquePtr pluginState, EventSourceInstanceOpaquePtr instance, IntPtr progress)
+        public static IntPtr GetReadProgress(void* pluginState, EventSourceInstanceOpaquePtr instance, IntPtr progress)
         {
             Marshal.WriteInt32(progress, 0);
             return IntPtr.Zero;
@@ -310,7 +338,7 @@ namespace {{namespace}}
         */
 
         [UnmanagedCallersOnly(EntryPoint = "plugin_event_to_string", CallConvs = new[] { typeof(CallConvCdecl) })]
-        public static IntPtr EventToString(PluginStateOpaquePtr pluginState, IntPtr pluginEvent)
+        public static IntPtr EventToString(void* pluginState, IntPtr pluginEvent)
         {
             return _eventSourceName;
         }
@@ -322,7 +350,7 @@ namespace {{namespace}}
         /// </remarks>
         [UnmanagedCallersOnly(EntryPoint = "plugin_next_batch", CallConvs = new[] { typeof(CallConvCdecl) })]
 
-        public static int GetNextEventsBatch(PluginStateOpaquePtr pluginState, EventSourceInstanceOpaquePtr instance, IntPtr numEvents, IntPtr events)
+        public static int GetNextEventsBatch(void* pluginState, EventSourceInstanceOpaquePtr instance, IntPtr numEvents, IntPtr events)
         {
             EventSourceInstanceContext? ctx = null;
             try
@@ -333,9 +361,7 @@ namespace {{namespace}}
 
                 Marshal.WriteInt32(numEvents, (int) ctx.BatchEventsNum);
 
-                Marshal.WriteIntPtr(
-                    events, 
-                    evtSourceInstance.EventBatch.UnderlyingArray);
+                events = (IntPtr) evtSourceInstance.EventBatch.UnderlyingArray;
 
                 if (ctx.IsEof)
                 {
@@ -390,7 +416,7 @@ namespace {{namespace}}
         /// NOTE: freed on extractRequest.SetPtr
         /// </remarks>
         [UnmanagedCallersOnly(EntryPoint = "plugin_extract_fields", CallConvs = new[] { typeof(CallConvCdecl) })]
-        public static int ExtractFields(PluginStateOpaquePtr pluginState, IntPtr pluginEvent, int numFields, IntPtr fieldsPtr)
+        public static int ExtractFields(void* pluginState, IntPtr pluginEvent, int numFields, IntPtr fieldsPtr)
         {
             try
             {

--- a/FalcoSecurity.Plugin.Sdk.PushPlugin/FalcoSecurity.Plugin.Sdk.PushPlugin.csproj
+++ b/FalcoSecurity.Plugin.Sdk.PushPlugin/FalcoSecurity.Plugin.Sdk.PushPlugin.csproj
@@ -11,7 +11,9 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="DNNE" Version="1.0.32" />
-		<PackageReference Include="FalcoSecurity.Plugin.Sdk" Version="0.1.3" />
-		<PackageReference Include="FalcoSecurity.Plugin.Sdk.Generators" Version="0.1.2" />
+	</ItemGroup>
+	<ItemGroup>
+	  <ProjectReference Include="..\FalcoSecurity.Plugin.Sdk.Generators\FalcoSecurity.Plugin.Sdk.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+	  <ProjectReference Include="..\FalcoSecurity.Plugin.Sdk\FalcoSecurity.Plugin.Sdk.csproj" />
 	</ItemGroup>
 </Project>

--- a/FalcoSecurity.Plugin.Sdk.PushPlugin/Plugin.cs
+++ b/FalcoSecurity.Plugin.Sdk.PushPlugin/Plugin.cs
@@ -51,7 +51,7 @@ namespace FalcoSecurity.Plugin.Sdk.PushPlugin
     [FalcoPlugin(
     Id = 999,
         Name = "dummy_plugin",
-        Description = "An example 'push mode' plugin",
+        Description = "An example 'push' mode plugin",
         Contacts = "mvenditto",
         RequiredApiVersion = "2.0.0",
         Version = "1.0.0")]

--- a/FalcoSecurity.Plugin.Sdk.PushPlugin/Plugin.cs
+++ b/FalcoSecurity.Plugin.Sdk.PushPlugin/Plugin.cs
@@ -37,9 +37,12 @@ namespace FalcoSecurity.Plugin.Sdk.PushPlugin
 
                     Counter++;
 
-                    Console.WriteLine($"Counter incremented c={Counter} delay={delay}");
+                    Console.WriteLine($"Counter -> {Counter}");
 
                     var timestamp = (ulong)DateTimeOffset.Now.ToUnixTimeSeconds() * 1000000000;
+
+                    Console.WriteLine($"Set timestamp: {timestamp}");
+
                     var data = BitConverter.GetBytes(Counter);
 
                     await EventsChannel.WriteAsync(new(timestamp, data), _cts.Token);

--- a/FalcoSecurity.Plugin.Sdk.Test/EventSourceTest.cs
+++ b/FalcoSecurity.Plugin.Sdk.Test/EventSourceTest.cs
@@ -23,7 +23,7 @@ namespace FalcoSecurity.Plugin.Sdk.Test
         [Fact]
         public void TestEventPoolSize()
         {
-            /*using*/ var eventPool = new EventBatch(size: 1, dataSize: 1);
+            using var eventPool = new EventBatch(size: 1, dataSize: 1);
 
             Assert.Equal(1, eventPool.Length);
         }
@@ -60,7 +60,6 @@ namespace FalcoSecurity.Plugin.Sdk.Test
             }
         }
 
-        /*
         [Fact]
         public void GetOnDisposedEventBatchThrows()
         {
@@ -70,13 +69,12 @@ namespace FalcoSecurity.Plugin.Sdk.Test
             {
                 _ = batch.Get(0);
             });
-        }       
-        */
+        }
 
         [Fact]
         public void GetOutOfRangeOnEventBatchThrows()
         {
-            /*using*/ var batch = new EventBatch(1, 1);
+            using var batch = new EventBatch(1, 1);
             Assert.Throws<IndexOutOfRangeException>(() =>
             {
                 _ = batch.Get(2);
@@ -86,42 +84,42 @@ namespace FalcoSecurity.Plugin.Sdk.Test
         [Fact]
         unsafe public void EventWriterNew()
         {
-            var evt = (PluginEvent*)Marshal.AllocHGlobal(sizeof(PluginEvent));
+            var evt = (PluginEvent*) NativeMemory.Alloc((nuint) sizeof(PluginEvent));
             var ew = new EventWriter(evt, 1);
             try
             {
                 Assert.Equal((nint) evt, (nint) ew.UnderlyingEvent);
                 ew.Free();
                 Assert.Equal(0u, evt->DataLen);
-                Assert.Equal(IntPtr.Zero, evt->Data);
+                Assert.Equal(0u, (nuint) evt->Data);
             }
             finally
             {
-                Marshal.FreeHGlobal((IntPtr)evt);
+                NativeMemory.Free(evt);
             }
         }
 
         [Fact]
         unsafe public void EventWriterFree()
         {
-            var evt = (PluginEvent*)Marshal.AllocHGlobal(sizeof(PluginEvent));
+            var evt = (PluginEvent*)NativeMemory.Alloc((nuint)sizeof(PluginEvent));
             var ew = new EventWriter(evt, 1);
             try
             {
                 ew.Free();
                 Assert.Equal(0u, evt->DataLen);
-                Assert.Equal(IntPtr.Zero, evt->Data);
+                Assert.Equal(0u, (nuint)evt->Data);
             }
             finally
             {
-                Marshal.FreeHGlobal((IntPtr) evt);
+                NativeMemory.Free(evt);
             }
         }
 
         [Fact]
         unsafe public void ReadWriteArbitraryData()
         {
-            var evt = (PluginEvent*)Marshal.AllocHGlobal(sizeof(PluginEvent));
+            var evt = (PluginEvent*)NativeMemory.Alloc((nuint)sizeof(PluginEvent));
 
             try
             {
@@ -148,20 +146,20 @@ namespace FalcoSecurity.Plugin.Sdk.Test
             }
             finally
             {
-                Marshal.FreeHGlobal((IntPtr) evt);
+                NativeMemory.Free(evt);
             }
         }
 
         [Fact]
         unsafe public void EventReaderTest()
         {
-            var evt = (PluginEvent*)Marshal.AllocHGlobal(sizeof(PluginEvent));
+            var evt = (PluginEvent*)NativeMemory.Alloc((nuint)sizeof(PluginEvent));
 
             const string data = "This is a test!";
             var dataBytes = Encoding.UTF8.GetBytes(data);
             var nanos = DateTimeOffset.Now.ToUnixTimeMilliseconds() * 1000000;
-            var dataBuff = Marshal.AllocHGlobal(dataBytes.Length);
-            dataBytes.CopyTo(new Span<byte>((void*) dataBuff, dataBytes.Length));
+            var dataBuff = NativeMemory.Alloc((nuint) dataBytes.Length);
+            dataBytes.CopyTo(new Span<byte>(dataBuff, dataBytes.Length));
 
             try
             {
@@ -178,8 +176,8 @@ namespace FalcoSecurity.Plugin.Sdk.Test
             }
             finally
             {
-                Marshal.FreeHGlobal(evt->Data);
-                Marshal.FreeHGlobal((IntPtr)evt);
+                NativeMemory.Free(evt->Data);
+                NativeMemory.Free(evt);
             }
         }
 
@@ -298,7 +296,7 @@ namespace FalcoSecurity.Plugin.Sdk.Test
         [Fact]
         public void PullEventSourceShouldTimeout()
         {
-            /*using*/ var instance = new TestPullEventSource(
+            using var instance = new TestPullEventSource(
                     EventSourceConsts.DefaultBatchSize,
                     EventSourceConsts.DefaultEventSize);
 
@@ -319,7 +317,7 @@ namespace FalcoSecurity.Plugin.Sdk.Test
         [Fact]
         public void PullEvenSourceShouldPropagateError()
         {
-            /*using*/ var instance = new TestPullEventSource(
+            using var instance = new TestPullEventSource(
                     EventSourceConsts.DefaultBatchSize,
                     EventSourceConsts.DefaultEventSize);
 
@@ -336,7 +334,7 @@ namespace FalcoSecurity.Plugin.Sdk.Test
         [Fact]
         public void PullEventSourceInstanceTest()
         {
-            /*using*/ var instance = new TestPullEventSource(
+            using var instance = new TestPullEventSource(
                     EventSourceConsts.DefaultBatchSize,
                     EventSourceConsts.DefaultEventSize);
 

--- a/FalcoSecurity.Plugin.Sdk.Test/ExtractFieldTest.cs
+++ b/FalcoSecurity.Plugin.Sdk.Test/ExtractFieldTest.cs
@@ -1,19 +1,26 @@
 using FalcoSecurity.Plugin.Sdk.Fields;
 using System.Runtime.InteropServices;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace FalcoSecurity.Plugin.Sdk.Test
 {
     public class ExtractFieldTest
     {
+        private readonly ITestOutputHelper _outputHelper;
+
+        public ExtractFieldTest(ITestOutputHelper outputHelper)
+        {
+            _outputHelper = outputHelper;
+        }
+        
         [Fact]
         unsafe public void ExtractionRequestSetU64ArrayValue()
         {
-            var fieldPtr = IntPtr.Zero;
+            void* fieldPtr = null;
             try
             {
-
-                fieldPtr = Marshal.AllocHGlobal(sizeof(PluginExtractField));
+                fieldPtr = NativeMemory.Alloc((nuint)sizeof(PluginExtractField));
 
                 var f = (PluginExtractField*) fieldPtr;
 
@@ -24,7 +31,7 @@ namespace FalcoSecurity.Plugin.Sdk.Test
 
                 using var er = new ExtractionRequest();
 
-                er.SetPtr(fieldPtr);
+                er.SetPtr(f);
 
                 var results = Enumerable
                     .Range(0, 512)
@@ -49,21 +56,18 @@ namespace FalcoSecurity.Plugin.Sdk.Test
             }
             finally
             {
-                if (fieldPtr != IntPtr.Zero)
-                {
-                    Marshal.FreeHGlobal(fieldPtr);
-                }
+                NativeMemory.Free(fieldPtr);
             }
         }
 
         [Fact]
         unsafe public void ExtractionRequestSetU64Value()
         {
-            var fieldPtr = IntPtr.Zero;
+            void* fieldPtr = null;
             try
             {
 
-                fieldPtr = Marshal.AllocHGlobal(sizeof(PluginExtractField));
+                fieldPtr = NativeMemory.Alloc((nuint)sizeof(PluginExtractField));
 
                 var f = (PluginExtractField*)fieldPtr;
 
@@ -74,7 +78,7 @@ namespace FalcoSecurity.Plugin.Sdk.Test
 
                 using var er = new ExtractionRequest();
 
-                er.SetPtr(fieldPtr);
+                er.SetPtr(f);
 
                 er.SetValue(42u);
 
@@ -84,21 +88,18 @@ namespace FalcoSecurity.Plugin.Sdk.Test
             }
             finally
             {
-                if (fieldPtr != IntPtr.Zero)
-                {
-                    Marshal.FreeHGlobal(fieldPtr);
-                }
+                NativeMemory.Free(fieldPtr);
             }
         }
 
         [Fact]
         unsafe public void ExtractionRequestSetStringValue()
         {
-            var fieldPtr = IntPtr.Zero;
+            void* fieldPtr = null;
             try
             {
 
-                fieldPtr = Marshal.AllocHGlobal(sizeof(PluginExtractField));
+                fieldPtr = NativeMemory.Alloc((nuint)sizeof(PluginExtractField));
 
                 var f = (PluginExtractField*)fieldPtr;
 
@@ -109,7 +110,7 @@ namespace FalcoSecurity.Plugin.Sdk.Test
 
                 using var er = new ExtractionRequest();
 
-                er.SetPtr(fieldPtr);
+                er.SetPtr(f);
 
                 er.SetValue("TEST");
 
@@ -123,23 +124,21 @@ namespace FalcoSecurity.Plugin.Sdk.Test
             }
             finally
             {
-                if (fieldPtr != IntPtr.Zero)
-                {
-                    Marshal.FreeHGlobal(fieldPtr);
-                }
+                NativeMemory.Free(fieldPtr);
             }
         }
 
         [Fact]
         unsafe public void ExtractionRequestSetStringArrayValue()
         {
-            var fieldPtr = IntPtr.Zero;
+            void* fieldPtr = null;
+
             try
             {
 
-                fieldPtr = Marshal.AllocHGlobal(sizeof(PluginExtractField));
+                fieldPtr = NativeMemory.Alloc((nuint)sizeof(PluginExtractField));
 
-                var f = (PluginExtractField*) fieldPtr;
+                var f = (PluginExtractField*)fieldPtr;
 
                 f->FieldList = 1;
                 f->ArgPresent = 0;
@@ -148,10 +147,10 @@ namespace FalcoSecurity.Plugin.Sdk.Test
 
                 using var er = new ExtractionRequest();
 
-                er.SetPtr(fieldPtr);
+                er.SetPtr(f);
 
                 var results = Enumerable
-                    .Range(0, 512)
+                    .Range(0, 3)
                     .Select(i => $"This is String {i}!")
                     .ToArray()!;
 
@@ -161,27 +160,25 @@ namespace FalcoSecurity.Plugin.Sdk.Test
 
                 for (var i = 0; i < results.Length; i++)
                 {
-                    string s = Marshal.PtrToStringUTF8(rawResults[i])!;
+                    var r = rawResults[i];
+                    string s = Marshal.PtrToStringUTF8(r)!;
                     Assert.Equal($"This is String {i}!", s);
                 }
             }
             finally
             {
-                if (fieldPtr != IntPtr.Zero)
-                {
-                    Marshal.FreeHGlobal(fieldPtr);
-                }
+                NativeMemory.Free(fieldPtr);
             }
         }
 
         [Fact]
         unsafe public void ShouldThrowArgumentExceptionIfWritingU64ToStringTypeField()
         {
-            var fieldPtr = IntPtr.Zero;
+            void* fieldPtr = null;
             try
             {
 
-                fieldPtr = Marshal.AllocHGlobal(sizeof(PluginExtractField));
+                fieldPtr = NativeMemory.Alloc((nuint)sizeof(PluginExtractField));
 
                 var f = (PluginExtractField*)fieldPtr;
 
@@ -192,28 +189,25 @@ namespace FalcoSecurity.Plugin.Sdk.Test
 
                 using var er = new ExtractionRequest();
 
-                er.SetPtr(fieldPtr);
+                er.SetPtr(f);
 
                 Assert.Throws<ArgumentException>(
                     () => er.SetValue(42u));
             }
             finally
             {
-                if (fieldPtr != IntPtr.Zero)
-                {
-                    Marshal.FreeHGlobal(fieldPtr);
-                }
+                NativeMemory.Free(fieldPtr);
             }
         }
 
         [Fact]
         unsafe public void ShouldThrowArgumentExceptionIfWritingStringToU64TypeField()
         {
-            var fieldPtr = IntPtr.Zero;
+            void* fieldPtr = null;
             try
             {
 
-                fieldPtr = Marshal.AllocHGlobal(sizeof(PluginExtractField));
+                fieldPtr = NativeMemory.Alloc((nuint)sizeof(PluginExtractField));
 
                 var f = (PluginExtractField*)fieldPtr;
 
@@ -224,28 +218,25 @@ namespace FalcoSecurity.Plugin.Sdk.Test
 
                 using var er = new ExtractionRequest();
 
-                er.SetPtr(fieldPtr);
+                er.SetPtr(f);
 
                 Assert.Throws<ArgumentException>(
                     () => er.SetValue(string.Empty));
             }
             finally
             {
-                if (fieldPtr != IntPtr.Zero)
-                {
-                    Marshal.FreeHGlobal(fieldPtr);
-                }
+                NativeMemory.Free(fieldPtr);
             }
         }
 
         [Fact]
         unsafe public void ShouldThrowArgumentExceptionIfWritingListToNonListField()
         {
-            var fieldPtr = IntPtr.Zero;
+            void* fieldPtr = null;
             try
             {
 
-                fieldPtr = Marshal.AllocHGlobal(sizeof(PluginExtractField));
+                fieldPtr = NativeMemory.Alloc((nuint)sizeof(PluginExtractField));
 
                 var f = (PluginExtractField*)fieldPtr;
 
@@ -256,28 +247,25 @@ namespace FalcoSecurity.Plugin.Sdk.Test
 
                 using var er = new ExtractionRequest();
 
-                er.SetPtr(fieldPtr);
+                er.SetPtr(f);
 
                 Assert.Throws<ArgumentException>(
                     () => er.SetValue(new ulong[] { 1, 2, 3, 4 }));
             }
             finally
             {
-                if (fieldPtr != IntPtr.Zero)
-                {
-                    Marshal.FreeHGlobal(fieldPtr);
-                }
+                NativeMemory.Free(fieldPtr);
             }
         }
 
         [Fact]
         unsafe public void ExtractionRequestPoolReturnMustNotFreeResourcesTest()
         {
-            var fieldPtr = IntPtr.Zero;
+            void* fieldPtr = null;
             try
             {
 
-                fieldPtr = Marshal.AllocHGlobal(sizeof(PluginExtractField));
+                fieldPtr = NativeMemory.Alloc((nuint)sizeof(PluginExtractField));
 
                 var f = (PluginExtractField*)fieldPtr;
 
@@ -294,7 +282,7 @@ namespace FalcoSecurity.Plugin.Sdk.Test
 
                 Assert.Equal(IntPtr.Zero, (IntPtr)r1.UnderlyingPtr);
 
-                r1.SetPtr(fieldPtr);
+                r1.SetPtr(f);
 
                 Assert.NotEqual(IntPtr.Zero, (IntPtr)r1.UnderlyingPtr);
 
@@ -308,10 +296,7 @@ namespace FalcoSecurity.Plugin.Sdk.Test
             }
             finally
             {
-                if (fieldPtr != IntPtr.Zero)
-                {
-                    Marshal.FreeHGlobal(fieldPtr);
-                }
+                NativeMemory.Free(fieldPtr);
             }
         }
     }

--- a/FalcoSecurity.Plugin.Sdk/Events/EventBatch.cs
+++ b/FalcoSecurity.Plugin.Sdk/Events/EventBatch.cs
@@ -33,7 +33,7 @@ namespace FalcoSecurity.Plugin.Sdk.Events
 
         public int Length => _size;
 
-        public void* UnderlyingArray => _eventsPtr;
+        public PluginEvent* UnderlyingArray => _eventsPtr;
 
         public void Dispose()
         {

--- a/FalcoSecurity.Plugin.Sdk/Events/EventReader.cs
+++ b/FalcoSecurity.Plugin.Sdk/Events/EventReader.cs
@@ -14,7 +14,7 @@
         public ulong Timestamp => _pluginEvent->Timestamp;
 
         public ReadOnlySpan<byte> Data => new(
-            (void*) _pluginEvent->Data, 
+             _pluginEvent->Data, 
             (int) _pluginEvent->DataLen);
     }
 }

--- a/FalcoSecurity.Plugin.Sdk/Events/EventWriter.cs
+++ b/FalcoSecurity.Plugin.Sdk/Events/EventWriter.cs
@@ -15,7 +15,7 @@ namespace FalcoSecurity.Plugin.Sdk.Events
             _dataSize = dataSize;
             _event = pluginEvent;
             _event->Timestamp = ulong.MaxValue;
-            _event->Data = Marshal.AllocHGlobal((int) dataSize);
+            _event->Data = NativeMemory.Alloc(dataSize);
             _event->DataLen = 0;
         }
 
@@ -26,9 +26,9 @@ namespace FalcoSecurity.Plugin.Sdk.Events
 
         public void Write(ReadOnlySpan<byte> bytes)
         {
-            var offset = (void*)(_event->Data + (int)_event->DataLen);
+            var offset = (nuint)_event->Data + _event->DataLen;
 
-            var span = new Span<byte>(offset, bytes.Length);
+            var span = new Span<byte>((void*) offset, bytes.Length);
 
             bytes.CopyTo(span);
 
@@ -37,8 +37,8 @@ namespace FalcoSecurity.Plugin.Sdk.Events
 
         public void Free()
         {
-            Marshal.FreeHGlobal(_event->Data);
-            _event->Data = IntPtr.Zero;
+            NativeMemory.Free(_event->Data);
+            _event->Data = null;
             _event->DataLen = 0;
         }
 

--- a/FalcoSecurity.Plugin.Sdk/Events/IEventBatch.cs
+++ b/FalcoSecurity.Plugin.Sdk/Events/IEventBatch.cs
@@ -6,6 +6,6 @@
 
         int Length { get; }
 
-        IntPtr UnderlyingArray { get; }
+        unsafe void* UnderlyingArray { get; }
     }
 }

--- a/FalcoSecurity.Plugin.Sdk/Events/IEventBatch.cs
+++ b/FalcoSecurity.Plugin.Sdk/Events/IEventBatch.cs
@@ -6,6 +6,6 @@
 
         int Length { get; }
 
-        unsafe void* UnderlyingArray { get; }
+        unsafe PluginEvent* UnderlyingArray { get; }
     }
 }

--- a/FalcoSecurity.Plugin.Sdk/Events/PluginEvent.cs
+++ b/FalcoSecurity.Plugin.Sdk/Events/PluginEvent.cs
@@ -10,9 +10,17 @@ namespace FalcoSecurity.Plugin.Sdk.Events
     {
         public ulong EventNum { get; set; }
 
-        public IntPtr Data { get; set; }
+        public unsafe void* Data { get; set; }
 
         public uint DataLen { get; set; }
+
+        unsafe public PluginEvent()
+        {
+            EventNum = 0;
+            Data = null;
+            DataLen = 0;
+            Timestamp = ulong.MaxValue;
+        }
 
         public ulong Timestamp { get; set; }
 
@@ -20,5 +28,26 @@ namespace FalcoSecurity.Plugin.Sdk.Events
         {
             return other.EventNum == EventNum;
         }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is PluginEvent @event && Equals(@event);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(EventNum);
+        }
+
+        public static bool operator ==(PluginEvent left, PluginEvent right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(PluginEvent left, PluginEvent right)
+        {
+            return !(left == right);
+        }
+
     }
 }

--- a/FalcoSecurity.Plugin.Sdk/Events/PluginEvent.cs
+++ b/FalcoSecurity.Plugin.Sdk/Events/PluginEvent.cs
@@ -14,6 +14,8 @@ namespace FalcoSecurity.Plugin.Sdk.Events
 
         public uint DataLen { get; set; }
 
+        public ulong Timestamp { get; set; }
+
         unsafe public PluginEvent()
         {
             EventNum = 0;
@@ -21,8 +23,6 @@ namespace FalcoSecurity.Plugin.Sdk.Events
             DataLen = 0;
             Timestamp = ulong.MaxValue;
         }
-
-        public ulong Timestamp { get; set; }
 
         public bool Equals(PluginEvent other)
         {

--- a/FalcoSecurity.Plugin.Sdk/FalcoSecurity.Plugin.Sdk.csproj
+++ b/FalcoSecurity.Plugin.Sdk/FalcoSecurity.Plugin.Sdk.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
 	<Title>The source generator for FalcoSecurity.Plugin.Sdk</Title>
-	<VersionPrefix>0.1.3</VersionPrefix>
+	<VersionPrefix>0.3.0</VersionPrefix>
 	<VersionSuffix></VersionSuffix>
 	<Authors>mvenditto</Authors>
 	<Company>mvenditto</Company>

--- a/FalcoSecurity.Plugin.Sdk/FalcoSecurity.Plugin.Sdk.csproj
+++ b/FalcoSecurity.Plugin.Sdk/FalcoSecurity.Plugin.Sdk.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
 	<Title>The source generator for FalcoSecurity.Plugin.Sdk</Title>
-	<VersionPrefix>0.3.0</VersionPrefix>
+	<VersionPrefix>0.4.1</VersionPrefix>
 	<VersionSuffix></VersionSuffix>
 	<Authors>mvenditto</Authors>
 	<Company>mvenditto</Company>

--- a/FalcoSecurity.Plugin.Sdk/Fields/IExtractionRequest.cs
+++ b/FalcoSecurity.Plugin.Sdk/Fields/IExtractionRequest.cs
@@ -2,7 +2,7 @@
 {
     public interface IExtractionRequest : IDisposable
     {
-        void SetPtr(IntPtr ptr);
+        unsafe void SetPtr(PluginExtractField* ptr);
 
         ulong FieldId { get; }
 

--- a/FalcoSecurity.Plugin.Sdk/Interfaces/IPlugin.cs
+++ b/FalcoSecurity.Plugin.Sdk/Interfaces/IPlugin.cs
@@ -4,6 +4,8 @@
     {
         string? LastError { get; set; }
 
+        string? ConfigRaw { get; set; }
+
         void Init();
 
         void Destroy();

--- a/FalcoSecurity.Plugin.Sdk/PluginBase.cs
+++ b/FalcoSecurity.Plugin.Sdk/PluginBase.cs
@@ -1,12 +1,16 @@
 ﻿using FalcoSecurity.Plugin.Sdk.Events;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Schema.Generation;
 using Newtonsoft.Json.Serialization;
+using System.Text.Json;
 
 namespace FalcoSecurity.Plugin.Sdk
 {
     public abstract class PluginBase: IPlugin
     {
         virtual public PluginSchemaType ConfigSchemaType => PluginSchemaType.None;
+
+        public string? ConfigRaw { get; set; }
 
         public string? LastError { get; set; }
 
@@ -26,6 +30,23 @@ namespace FalcoSecurity.Plugin.Sdk
         public T? Config { get; set; }
 
         public override PluginSchemaType ConfigSchemaType => PluginSchemaType.Json;
+
+        public override void Init()
+        {
+            base.Init();
+
+            if (!string.IsNullOrEmpty(ConfigRaw))
+            {
+                try
+                {
+                    Config = System.Text.Json.JsonSerializer.Deserialize<T>(ConfigRaw);
+                }
+                catch (System.Text.Json.JsonException jex)
+                {
+                    Console.Error.WriteLine($"Cannot parse plugin config: {jex}");
+                }
+            }
+        }
 
         public bool TryGenerateJsonSchema(out string? jsonSchema)
         {

--- a/FalcoSecurity.Plugin.Sdk/Types/ExtractionField.cs
+++ b/FalcoSecurity.Plugin.Sdk/Types/ExtractionField.cs
@@ -4,12 +4,13 @@ namespace FalcoSecurity.Plugin.Sdk
 {
     public record ExtractionField
     {
-        public ExtractionField(string type, string name, string desc, string display="")
+        public ExtractionField(string type, string name, string desc, string display="", bool isList=false)
         {
             Type = type;
             Name = name;
             Description = desc;
             Display = display;
+            IsList = isList;
         }
 
         [JsonPropertyName("name")]

--- a/interop/test/build.sh
+++ b/interop/test/build.sh
@@ -1,5 +1,13 @@
 #!/bin/sh
 
+rm -r ../../FalcoSecurity.Plugin.Sdk.Generators/bin
+rm -r ../../FalcoSecurity.Plugin.Sdk.Generators/obj
+rm -r ../../test-plugins/PluginAll/bin
+rm -r ../../test-plugins/PluginAll/obj
+rm -r ../../test-plugins/PluginEventSourceOnly/bin
+rm -r ../../test-plugins/PluginEventSourceOnly/obj
+rm -r ../../test-plugins/PluginFieldExtractionOnly/bin
+rm -r ../../test-plugins/PluginFieldExtractionOnly/obj
 dotnet build ../../FalcoSecurity.Plugin.Sdk.Generators/FalcoSecurity.Plugin.Sdk.Generators.csproj --configuration Release --runtime linux-x64 --no-self-contained
 dotnet build ../../test-plugins/PluginAll/FalcoSecurity.Plugin.Sdk.Test.PluginAllCaps.csproj --configuration Release --runtime linux-x64 --no-self-contained &&
 dotnet build ../../test-plugins/PluginEventSourceOnly/FalcoSecurity.Plugin.Sdk.Test.PluginEventSourceOnly.csproj --configuration Release --runtime linux-x64 --no-self-contained &&

--- a/run_tests.ps1
+++ b/run_tests.ps1
@@ -1,0 +1,8 @@
+#! /usr/bin/env pwsh
+
+dotnet test `
+  --no-build `
+  --diag:logs/logs.txt `
+  --blame `
+  --blame-crash `
+  --logger "console;verbosity=detailed"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+dotnet test \
+    --no-build \
+    --diag:logs/logs.txt \
+    --blame \
+    --blame-crash \
+    --logger "console;verbosity=detailed" \
+    --runtime linux-x64

--- a/test-plugins/PluginAll/FalcoSecurity.Plugin.Sdk.Test.PluginAllCaps.csproj
+++ b/test-plugins/PluginAll/FalcoSecurity.Plugin.Sdk.Test.PluginAllCaps.csproj
@@ -8,6 +8,7 @@
 		<DnneAddGeneratedBinaryToProject>true</DnneAddGeneratedBinaryToProject>
 		<DnneNativeBinaryName>plugin_native</DnneNativeBinaryName>
 		<PublishSingleFile>true</PublishSingleFile>
+		<DnneCompilerUserFlags>$(DnneCompilerUserFlags)$(MSBuildThisFileDirectory)override.c</DnneCompilerUserFlags>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="DNNE" Version="1.0.32" />

--- a/test-plugins/PluginAll/Plugin.cs
+++ b/test-plugins/PluginAll/Plugin.cs
@@ -3,6 +3,23 @@ using FalcoSecurity.Plugin.Sdk.Fields;
 
 namespace FalcoSecurity.Plugin.Sdk.Test
 {
+    internal class EventSourceIntance : PullEventSourceInstance
+    {
+        private int _counter = 0;
+
+        public EventSourceIntance() : base(10, sizeof(int))
+        {
+            TimeoutMs = 0;
+        }
+
+        protected override void PullEvent(EventSourceInstanceContext ctx, IEventWriter evt)
+        {
+            evt.SetTimestamp(ulong.MaxValue);
+            evt.Write(BitConverter.GetBytes(_counter));
+            _counter += 1;
+        }
+    }
+
     [FalcoPlugin(
         Id = 999,
         Name = "test_plugin",
@@ -26,7 +43,7 @@ namespace FalcoSecurity.Plugin.Sdk.Test
 
         public IEventSourceInstance Open(IEnumerable<OpenParam>? openParams)
         {
-            throw new NotImplementedException();
+            return new EventSourceIntance();
         }
 
         public void Close(IEventSourceInstance instance)
@@ -36,7 +53,7 @@ namespace FalcoSecurity.Plugin.Sdk.Test
 
         public void Extract(IExtractionRequest extraction, IEventReader evt)
         {
-            throw new NotImplementedException();
+            extraction.SetValue((ulong) BitConverter.ToInt32(evt.Data));
         }
     }
 }

--- a/test-plugins/PluginAll/Plugin.cs
+++ b/test-plugins/PluginAll/Plugin.cs
@@ -17,9 +17,9 @@ namespace FalcoSecurity.Plugin.Sdk.Test
         public IEnumerable<OpenParam> OpenParameters
             => Enumerable.Empty<OpenParam>();
 
-        public IEnumerable<ExtractionField> Fields
-            => Enumerable.Empty<ExtractionField>();
-
+        public IEnumerable<ExtractionField> Fields => new List<ExtractionField> { 
+            new("uint64", "dummy", "dummy field")
+        };
 
         public IEnumerable<string> EventSourcesToExtract
             => Enumerable.Empty<string>();

--- a/test-plugins/PluginAll/override.c
+++ b/test-plugins/PluginAll/override.c
@@ -1,0 +1,29 @@
+﻿// Copyright 2021 Aaron R Robinson
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <dnne.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+// Define override of built-in rude-abort API.
+DNNE_API void dnne_abort(enum failure_type type, int error_code)
+{
+    printf("Custom dnne_abort() - %d, %d\n", type, error_code);
+    exit(error_code);
+}

--- a/test-plugins/PluginEventSourceOnly/Plugin.cs
+++ b/test-plugins/PluginEventSourceOnly/Plugin.cs
@@ -3,6 +3,25 @@ using FalcoSecurity.Plugin.Sdk.Fields;
 
 namespace FalcoSecurity.Plugin.Sdk.Test
 {
+
+    internal class EventSourceIntance : PullEventSourceInstance
+    {
+        private int _counter = 0;
+
+        public EventSourceIntance() : base(10, sizeof(int))
+        {
+            TimeoutMs = 0;
+        }
+
+        protected override void PullEvent(EventSourceInstanceContext ctx, IEventWriter evt)
+        {
+            evt.SetTimestamp(ulong.MaxValue);
+            evt.Write(BitConverter.GetBytes(_counter));
+            _counter += 1;
+        }
+    }
+
+
     [FalcoPlugin(
         Id = 999,
         Name = "test_plugin",
@@ -19,7 +38,7 @@ namespace FalcoSecurity.Plugin.Sdk.Test
 
         public IEventSourceInstance Open(IEnumerable<OpenParam>? openParams)
         {
-            throw new NotImplementedException();
+            return new EventSourceIntance();
         }
 
         public void Close(IEventSourceInstance instance)

--- a/test-plugins/PluginFieldExtractionOnly/Plugin.cs
+++ b/test-plugins/PluginFieldExtractionOnly/Plugin.cs
@@ -26,7 +26,10 @@ namespace FalcoSecurity.Plugin.Sdk.Test
 
         public void Extract(IExtractionRequest extraction, IEventReader evt)
         {
-            throw new NotImplementedException();
+            if (extraction.FieldName == "test.int")
+            {
+                extraction.SetValue((ulong) BitConverter.ToInt32(evt.Data));
+            }
         }
     }
 }

--- a/test-plugins/PluginFieldExtractionOnly/Plugin.cs
+++ b/test-plugins/PluginFieldExtractionOnly/Plugin.cs
@@ -14,8 +14,10 @@ namespace FalcoSecurity.Plugin.Sdk.Test
     {
         public IEnumerable<ExtractionField> Fields => new List<ExtractionField>
         {
-            new(type: "uint64", name: "test.int", desc: "an int field", display: "<int>"),
-            new(type: "string", name: "test.str", desc: "a str field", display: "<str>"),
+            new(type: "uint64", name: "test.u64", desc: "an integer field", display: "<u64>"),
+            new(type: "string", name: "test.str", desc: "a string field", display: "<str>"),
+            new(type: "uint64", name: "test.[u64]", isList: true, desc: "an integer[] field", display: "<u64[]>"),
+            new(type: "string", name: "test.[str]", isList: true, desc: "a string[] field", display: "<str[]>")
         };
 
         public IEnumerable<string> EventSourcesToExtract => new List<string>
@@ -26,9 +28,35 @@ namespace FalcoSecurity.Plugin.Sdk.Test
 
         public void Extract(IExtractionRequest extraction, IEventReader evt)
         {
-            if (extraction.FieldName == "test.int")
+            var counter = (ulong) BitConverter.ToInt32(evt.Data);
+
+            if (extraction.FieldName == "test.u64")
             {
-                extraction.SetValue((ulong) BitConverter.ToInt32(evt.Data));
+                extraction.SetValue(counter);
+            }
+            else if (extraction.FieldName == "test.str")
+            {
+                extraction.SetValue($"Counter = {counter}");
+            }
+            else if (extraction.FieldName == "test.[u64]")
+            {
+                var elementsCount = (int) Math.Max(1, counter);
+                var elements = new ulong[elementsCount];
+                for (var i = 0; i < elementsCount; i++)
+                {
+                    elements[i] = (ulong) i;
+                }
+                extraction.SetValue(elements);
+            }
+            else if (extraction.FieldName == "test.[str]")
+            {
+                var elementsCount = (int)Math.Max(1, counter);
+                var elements = new string[elementsCount];
+                for (var i = 0; i < elementsCount; i++)
+                {
+                    elements[i] = $"Counter: {i}";
+                }
+                extraction.SetValue(elements);
             }
         }
     }


### PR DESCRIPTION
### Highlights
- switched to the newest and more portable NET6+ [`NativeMemeory`](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.nativememory?view=net-6.0) (a thin thin wrapper around C malloc) instead of  using `Marshal` memory methods.
- fixed few memory leaks
- added many interop-tests covering event sourcing and field extraction
- for more info on bugfixes an breaking changes look at the changelog 

Closes #4 
